### PR TITLE
Clarified version to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Technology Stack
 * Groovy for production and test code.
 * Spock for automated unit tests.
 * Batik for SVG Generation.
-* Gradle build tool.
+* Gradle build tool.  Install Gradle 4.10.x from https://gradle.org/releases/
 
 Running Tests
 =============


### PR DESCRIPTION
Installed Gradle 6 and Gradle 5.  The build fails because of an incompatible plugin.  With Gradle 4.10.2 I was able to successfully build.