### PR TITLE
Add support for board mirroring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Usage: pnpconvert
                             Fiducial marker list (note,x,y[ ...])
       -ft                   Generate DPV containing all feeders
   -i=<input>                input csv file/url
+  -m=<mirroring>            mirroring mode (horizontal/vertical/both/none),
+                              default is none
+      -mx=<mirroringX>      mirroring X origin
+      -my=<mirroringY>      mirroring Y origin
   -o=<output>               output prefix
       -ox=<offsetX>         X offset, applied after rotation
       -oy=<offsetY>         Y offset, applied after rotation
@@ -203,12 +207,13 @@ Components in the design file that are matched to components using aliases, or t
 SVG file
 ========
 
-| Color | Usage  |
-| ----- | ------ |
-| Red | Starting Coordinate |
-| Blue | Coordinate after rotation |
-| Pink | Coordinate after rotation and rotation coordinate offset |
-| Green | Final coordinate after rotation, rotation coordinate offset and origin offset |
+| Color  | Usage  |
+| ------ | ------ |
+| Red    | Starting Coordinate |
+| Yellow | Coordinate after mirroring |
+| Blue   | Coordinate after mirroring, rotation |
+| Pink   | Coordinate after mirroring, rotation and rotation coordinate offset |
+| Green  | Final coordinate after mirroring, rotation, rotation coordinate offset and origin offset |
 
 CSV files
 =========

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ clover {
         '**/CSVInput.groovy',
         '**/Feeders.groovy',
         '**/FeederTester.groovy',
+        '**/BoardMirroring.groovy',
+        '**/DiptraceComponentPlacementTransformer.groovy',
         '**/DipTraceLineParser.groovy',
         '**/DPVFile.groovy',
     ]

--- a/src/main/groovy/com/seriouslypro/pnpconvert/BoardMirroring.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/BoardMirroring.groovy
@@ -1,0 +1,22 @@
+package com.seriouslypro.pnpconvert
+
+class BoardMirroring {
+    Mirroring.Mode mode = Mirroring.Mode.NONE
+    Coordinate origin = new Coordinate(x: 0.0G, y: 0.0G)
+
+    Coordinate applyMirroring(Coordinate coordinate) {
+
+        Coordinate m
+
+        if (mode == Mirroring.Mode.HORIZONTAL) {
+            m = new Coordinate(x: coordinate.x, y: origin.y - (coordinate.y - origin.y))
+        } else if (mode == Mirroring.Mode.VERTICAL) {
+            m = new Coordinate(x: origin.x - (coordinate.x - origin.x), y: coordinate.y)
+        } else if (mode == Mirroring.Mode.BOTH) {
+            m = new Coordinate(x: origin.x - (coordinate.x - origin.x), y: origin.y - (coordinate.y - origin.y))
+        } else {
+            m = coordinate
+        }
+        return m
+    }
+}

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
@@ -15,6 +15,7 @@ class Converter {
     Machine machine
 
     BoardRotation boardRotation = new BoardRotation()
+    BoardMirroring boardMirroring = new BoardMirroring()
     Coordinate offsetXY = new Coordinate()
     BigDecimal offsetZ = 0
     PCBSideComponentPlacementFilter.SideInclusion sideInclusion = PCBSideComponentPlacementFilter.SideInclusion.ALL
@@ -40,7 +41,7 @@ class Converter {
 
         String transformFileName = outputPrefix + "-transformed.csv"
 
-        ComponentPlacementTransformer transformer = new DiptraceComponentPlacementTransformer(outputPrefix, boardRotation, offsetXY)
+        ComponentPlacementTransformer transformer = new DiptraceComponentPlacementTransformer(outputPrefix, boardRotation, boardMirroring, offsetXY)
         ComponentPlacementWriter dipTraceComponentPlacementWriter = new DipTraceComponentPlacementWriter(transformFileName)
 
 

--- a/src/main/groovy/com/seriouslypro/pnpconvert/DPVGenerator.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/DPVGenerator.groovy
@@ -87,9 +87,10 @@ class DPVGenerator {
                 component           : [
                     name   : materialAssigment.value.component.name,
                     aliases: materialAssigment.value.component.aliases,
-                ].toString(),
+                ],
             ]
         }
+
         if (!summaryItems.isEmpty()) {
             System.out.println()
             System.out.println("feederSummary:")

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Mirroring.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Mirroring.groovy
@@ -1,0 +1,10 @@
+package com.seriouslypro.pnpconvert
+
+class Mirroring {
+    static enum Mode {
+        NONE,
+        BOTH,
+        HORIZONTAL,
+        VERTICAL
+    }
+}

--- a/src/main/groovy/com/seriouslypro/pnpconvert/PNPConvert.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/PNPConvert.groovy
@@ -27,6 +27,10 @@ class PNPConvert {
         builder.rx(args:1, argName: 'rotationX', 'rotation X origin')
         builder.ry(args:1, argName: 'rotationY', 'rotation Y origin')
 
+        builder.m(args:1, argName: 'mirroring', 'mirroring mode (horizontal/vertical/both/none), default is none')
+        builder.mx(args:1, argName: 'mirroringX', 'mirroring X origin')
+        builder.my(args:1, argName: 'mirroringY', 'mirroring Y origin')
+
         builder.ox(args:1, argName: 'offsetX', 'X offset, applied after rotation')
         builder.oy(args:1, argName: 'offsetY', 'Y offset, applied after rotation')
         builder.oz(args:1, argName: 'offset', 'Z offset, applied to all component heights - increase for thicker PCBs')
@@ -80,6 +84,7 @@ class PNPConvert {
         String componentsFileName = config.getOrDefault("components","components.csv")
 
         BoardRotation boardRotation = new BoardRotation()
+        BoardMirroring boardMirroring = new BoardMirroring()
         Coordinate offsetXY = new Coordinate()
         BigDecimal offsetZ = 0
         PCBSideComponentPlacementFilter.SideInclusion sideInclusion = PCBSideComponentPlacementFilter.SideInclusion.ALL
@@ -120,6 +125,18 @@ class PNPConvert {
 
         if (options.ry) {
             boardRotation.origin.y = (options.ry as BigDecimal)
+        }
+
+        if (options.m) {
+            boardMirroring.mode = parseMirroring(options.m)
+        }
+
+        if (options.mx ) {
+            boardMirroring.origin.x = (options.mx as BigDecimal)
+        }
+
+        if (options.my) {
+            boardMirroring.origin.y = (options.my as BigDecimal)
         }
 
         if (options.ox ) {
@@ -181,6 +198,7 @@ class PNPConvert {
                 componentsFileName: componentsFileName,
                 outputPrefix: outputPrefix,
                 boardRotation: boardRotation,
+                boardMirroring: boardMirroring,
                 offsetXY: offsetXY,
                 offsetZ: offsetZ,
                 sideInclusion: sideInclusion,
@@ -238,6 +256,17 @@ class PNPConvert {
         }
 
         return Optional.of(fiducials)
+    }
+
+    static Mirroring.Mode parseMirroring(String arg) {
+        String uppercaseArg = arg.toUpperCase()
+        try {
+            Mirroring.Mode mode = Mirroring.Mode.valueOf(uppercaseArg)
+            return mode
+        } catch (Exception e) {
+            String[] candidates = Mirroring.Mode.values()
+            throw new IllegalArgumentException("Unknown mode: $arg, expected $candidates", e)
+        }
     }
 
     static PCBSideComponentPlacementFilter.SideInclusion parseSideInclusion(String arg) {

--- a/src/test/groovy/com/seriouslypro/pnpconvert/BoardMirroringSpec.groovy
+++ b/src/test/groovy/com/seriouslypro/pnpconvert/BoardMirroringSpec.groovy
@@ -1,0 +1,59 @@
+package com.seriouslypro.pnpconvert
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BoardMirroringSpec extends Specification {
+
+    public static final Coordinate zeroCoordinate = new Coordinate(x: 0.0G, y: 0.0G)
+
+    BoardMirroring boardMirroring
+
+    void setup() {
+    }
+
+    def "no mirroring - zero coordinate"() {
+        given:
+            boardMirroring = new BoardMirroring(mode: Mirroring.Mode.NONE)
+
+        expect:
+            zeroCoordinate == boardMirroring.applyMirroring(zeroCoordinate)
+    }
+
+    def "both - zero coordinate"() {
+        given:
+            boardMirroring = new BoardMirroring(mode: Mirroring.Mode.BOTH)
+
+        expect:
+            zeroCoordinate == boardMirroring.applyMirroring(zeroCoordinate)
+    }
+
+    @Unroll
+    def "mirroring with origin (point: #x, #y, mode: #mode, origin: #originX, #originY)"() {
+        given:
+            boardMirroring = new BoardMirroring(mode: mode, origin: new Coordinate(x: originX, y: originY))
+            Coordinate expectedCoordinate = new Coordinate(
+                x: expectedX,
+                y: expectedY
+            )
+        expect:
+            expectedCoordinate == boardMirroring.applyMirroring(new Coordinate(x: x, y: y))
+
+        where:
+            x   | y   | mode                      | originX | originY | expectedX | expectedY
+            0   | 0   | Mirroring.Mode.NONE       | 0       | 0       | 0         | 0
+            0   | 1   | Mirroring.Mode.HORIZONTAL | 0       | 0       | 0         | -1
+            0   | 2   | Mirroring.Mode.HORIZONTAL | 0       | 1       | 0         | 0
+            0   | 10  | Mirroring.Mode.HORIZONTAL | 0       | 5       | 0         | 0
+            0   | 0   | Mirroring.Mode.HORIZONTAL | 0       | 5       | 0         | 10
+            1   | 0   | Mirroring.Mode.VERTICAL   | 0       | 0       | -1        | 0
+            2   | 0   | Mirroring.Mode.VERTICAL   | 1       | 0       | 0         | 0
+            10  | 0   | Mirroring.Mode.VERTICAL   | 5       | 0       | 0         | 0
+            0   | 0   | Mirroring.Mode.VERTICAL   | 5       | 0       | 10        | 0
+            1   | 1   | Mirroring.Mode.BOTH       | 0       | 0       | -1        | -1
+            2   | 2   | Mirroring.Mode.BOTH       | 1       | 1       | 0         | 0
+            10  | 10  | Mirroring.Mode.BOTH       | 5       | 5       | 0         | 0
+            0   | 0   | Mirroring.Mode.BOTH       | 5       | 5       | 10        | 10
+    }
+
+}


### PR DESCRIPTION
The 'mirror' export feature of diptrace adjusts the component origin which might not be desirable.  This feature applies mirroring and hopefully correct rotation as appropriate.

- [x] Test on new designs.
- [x] Test on old designs.
- [ ] Add more unit/integration tests.
- [ ] Update documentation.
- [ ] Add example files for mirroring.