### PR TITLE
Add feeder name and component to DPV file to aid with updating tray definitions.

### DIFF
--- a/src/main/groovy/com/seriouslypro/pnpconvert/DPVWriter.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/DPVWriter.groovy
@@ -189,6 +189,8 @@ class DPVWriter {
                 tray.columns,
                 tray.rows,
                 tray.firstComponentIndex,
+                tray.name,
+                materialAssignment.component.name
             ]
 
             return trayRow
@@ -333,7 +335,7 @@ class DPVWriter {
     }
 
     void writeTrays(List<String[]> trays) {
-        String sectionHeader = "Table,No.,ID,CenterX,CenterY,IntervalX,IntervalY,NumX,NumY,Start"
+        String sectionHeader = "Table,No.,ID,CenterX,CenterY,IntervalX,IntervalY,NumX,NumY,Start,Name,Component"
 
         stream.print(sectionHeader + tableLineEnding)
 


### PR DESCRIPTION
Note: The machine ignores the 'Name' and 'Component' columns.

Makes updating tray definitions by comparing updated file exported from the machine against the file that was uploaded to the machine easier.