### PR TITLE
Add panel and fiducials to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ SVG file
 | Pink   | Coordinate after mirroring, rotation and rotation coordinate offset |
 | Green  | Final coordinate after mirroring, rotation, rotation coordinate offset and origin offset |
 | Orange | Fiducial Marker |
+| Magenta | Panel |
 
 CSV files
 =========

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ SVG file
 | Blue   | Coordinate after mirroring, rotation |
 | Pink   | Coordinate after mirroring, rotation and rotation coordinate offset |
 | Green  | Final coordinate after mirroring, rotation, rotation coordinate offset and origin offset |
+| Orange | Fiducial Marker |
 
 CSV files
 =========

--- a/src/main/groovy/com/seriouslypro/pnpconvert/CSVProcessor.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/CSVProcessor.groovy
@@ -46,8 +46,6 @@ class CSVProcessor {
 
         writer.close()
 
-        transformer.close()
-
         return placements
     }
 }

--- a/src/main/groovy/com/seriouslypro/pnpconvert/ComponentPlacementTransformer.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/ComponentPlacementTransformer.groovy
@@ -3,6 +3,4 @@ package com.seriouslypro.pnpconvert
 interface ComponentPlacementTransformer {
 
     ComponentPlacement process(ComponentPlacement componentPlacement)
-
-    void close()
 }

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
@@ -2,6 +2,8 @@ package com.seriouslypro.pnpconvert
 
 import com.seriouslypro.pnpconvert.machine.Machine
 
+import java.awt.Color
+
 import static FileTools.*
 
 class Converter {
@@ -41,7 +43,9 @@ class Converter {
 
         String transformFileName = outputPrefix + "-transformed.csv"
 
-        ComponentPlacementTransformer transformer = new DiptraceComponentPlacementTransformer(outputPrefix, boardRotation, boardMirroring, offsetXY)
+        SVGRenderer svgRenderer = new SVGRenderer()
+
+        ComponentPlacementTransformer transformer = new DiptraceComponentPlacementTransformer(svgRenderer, boardRotation, boardMirroring, offsetXY)
         ComponentPlacementWriter dipTraceComponentPlacementWriter = new DipTraceComponentPlacementWriter(transformFileName)
 
 
@@ -50,6 +54,11 @@ class Converter {
         csvProcessor = new CSVProcessor(filter: filter, transformer: transformer, writer: dipTraceComponentPlacementWriter)
 
         List<ComponentPlacement> placements = csvProcessor.process(inputFileName)
+
+        svgRenderer.drawFiducials(optionalFiducials, Color.ORANGE)
+
+        String svgFileName = outputPrefix + ".svg"
+        svgRenderer.save(svgFileName)
 
         //
         // Disable components by refdes

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Converter.groovy
@@ -56,6 +56,7 @@ class Converter {
         List<ComponentPlacement> placements = csvProcessor.process(inputFileName)
 
         svgRenderer.drawFiducials(optionalFiducials, Color.ORANGE)
+        svgRenderer.drawPanel(optionalPanel, Color.MAGENTA)
 
         String svgFileName = outputPrefix + ".svg"
         svgRenderer.save(svgFileName)

--- a/src/main/groovy/com/seriouslypro/pnpconvert/DiptraceComponentPlacementTransformer.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/DiptraceComponentPlacementTransformer.groovy
@@ -5,14 +5,13 @@ import java.awt.Color
 
 class DiptraceComponentPlacementTransformer implements ComponentPlacementTransformer {
 
-    SVGRenderer renderer = new SVGRenderer()
-    String outputPrefix
+    SVGRenderer renderer
     BoardRotation boardRotation
     BoardMirroring boardMirroring
     Coordinate offset
 
-    DiptraceComponentPlacementTransformer(String outputPrefix, BoardRotation boardRotation, BoardMirroring boardMirroring, Coordinate offset) {
-        this.outputPrefix = outputPrefix
+    DiptraceComponentPlacementTransformer(SVGRenderer renderer, BoardRotation boardRotation, BoardMirroring boardMirroring, Coordinate offset) {
+        this.renderer = renderer
         this.boardRotation = boardRotation
         this.boardMirroring = boardMirroring
         this.offset = offset
@@ -23,12 +22,6 @@ class DiptraceComponentPlacementTransformer implements ComponentPlacementTransfo
         ComponentPlacement transformedComponentPlacement = transformAndRender(renderer, componentPlacement)
 
         return transformedComponentPlacement
-    }
-
-    @Override
-    void close() {
-        String svgFileName = outputPrefix + ".svg"
-        renderer.save(svgFileName)
     }
 
     private ComponentPlacement transformAndRender(SVGRenderer renderer, ComponentPlacement componentPlacement) {

--- a/src/main/groovy/com/seriouslypro/pnpconvert/SVGRenderer.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/SVGRenderer.groovy
@@ -19,6 +19,9 @@ class SVGRenderer {
     int refdesFontSize = 4
     Font refdesFont
 
+    int fiducialFontSize = 4
+    Font fiducialFont
+
     SVGRenderer() {
 
         DOMImplementation domImpl =
@@ -32,6 +35,7 @@ class SVGRenderer {
 
         svgGenerator = new SVGGraphics2D(ctx, false)
         refdesFont = new Font(Font.MONOSPACED, Font.PLAIN, refdesFontSize)
+        fiducialFont = new Font(Font.MONOSPACED, Font.PLAIN, fiducialFontSize)
     }
 
     void drawPart(Color color, Coordinate coordinate, String refdes, BigDecimal rotation) {
@@ -67,9 +71,39 @@ class SVGRenderer {
         svgGenerator.setFont(refdesFont)
         int baseline = refdesFont.getBaselineFor(refdes.charAt(0))
         svgGenerator.drawString(refdes, x + pointSize, y - baseline + ((refdesFontSize / 2) as int) - ((pointSize / 2) as int))
-
     }
 
+    void drawFiducials(Optional<List<Fiducial>> optionalFiducials, Color color) {
+        if (!optionalFiducials.present) {
+            return
+        }
+
+        List<Fiducial> fiducialList = optionalFiducials.get()
+
+        fiducialList.each { fiducial ->
+            drawFiducial(fiducial, color)
+        }
+    }
+
+    void drawFiducial(Fiducial fiducial, Color color) {
+        int pointSize = 2
+        int x = (fiducial.coordinate.x * scale)
+        int y = - (fiducial.coordinate.y * scale)
+
+        //
+        // mark
+        //
+        svgGenerator.setColor(color)
+        svgGenerator.drawLine(x - (pointSize / 2) as int, y - (pointSize / 2) as int, x + (pointSize / 2) as int, y + (pointSize / 2) as int)
+        svgGenerator.drawLine(x + (pointSize / 2) as int, y - (pointSize / 2) as int, x - (pointSize / 2) as int, y + (pointSize / 2) as int)
+
+        //
+        // note
+        //
+        svgGenerator.setFont(fiducialFont)
+        int baseline = refdesFont.getBaselineFor(fiducial.note.charAt(0))
+        svgGenerator.drawString(fiducial.note, x + pointSize, y - baseline + ((fiducialFontSize / 2) as int) - ((pointSize / 2) as int))
+    }
 
     void save(String svgFileName) {
         Element root = svgGenerator.getRoot();
@@ -78,11 +112,11 @@ class SVGRenderer {
 
         root.setAttributeNS(null, "viewBox", viewBox.join(' '));
 
-        boolean useCSS = true; // we want to use CSS style attributes
+        boolean useCSS = true // we want to use CSS style attributes
 
-        Writer svgFileWriter = new OutputStreamWriter(new FileOutputStream(svgFileName), "UTF-8");
+        Writer svgFileWriter = new OutputStreamWriter(new FileOutputStream(svgFileName), "UTF-8")
 
-        svgGenerator.stream(root, svgFileWriter, useCSS, false);
+        svgGenerator.stream(root, svgFileWriter, useCSS, false)
         svgFileWriter.close()
     }
 }

--- a/src/main/groovy/com/seriouslypro/pnpconvert/SVGRenderer.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/SVGRenderer.groovy
@@ -105,6 +105,23 @@ class SVGRenderer {
         svgGenerator.drawString(fiducial.note, x + pointSize, y - baseline + ((fiducialFontSize / 2) as int) - ((pointSize / 2) as int))
     }
 
+    void drawPanel(Optional<Panel> optionalPanel, Color color) {
+        if (!optionalPanel.present) {
+            return
+        }
+
+        Panel panel = optionalPanel.get()
+
+        //
+        // bounding box
+        //
+        svgGenerator.setColor(color)
+
+        int panelWidthScaled = (panel.intervalX * panel.numberX) * scale
+        int panelHeightScaled = (panel.intervalY * panel.numberY) * scale
+        svgGenerator.drawRect(0, 0 - panelHeightScaled, panelWidthScaled, panelHeightScaled)
+    }
+
     void save(String svgFileName) {
         Element root = svgGenerator.getRoot();
         List<Integer> viewBox = [-100,-100,200,200]
@@ -119,4 +136,5 @@ class SVGRenderer {
         svgGenerator.stream(root, svgFileWriter, useCSS, false)
         svgFileWriter.close()
     }
+
 }


### PR DESCRIPTION
Makes it easy to visually check the rotation and offsets are correct *before* uploading to the machine which results in an improved workflow.

Example of a design with rotation, panelling and fiducials.  Screengrab from InkScape (ignore the vertical grey line, it's not part of the SVG):

![image](https://user-images.githubusercontent.com/57075/125780550-2c94400f-9ba4-4ecd-93e1-41fee04fb5ed.png)
