### PR TITLE
Use updated dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,29 +49,29 @@ classes {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:3.0.7'
-    compile 'commons-codec:commons-codec:1.10'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.7'
+    implementation 'commons-codec:commons-codec:1.10'
     testImplementation 'org.spockframework:spock-core:2.0-M4-groovy-3.0'
     testImplementation 'org.spockframework:spock-junit4:2.0-M4-groovy-3.0'
-    testCompile group: 'cglib', name: 'cglib-nodep', version: '2.2'
-    testCompile group: 'org.objenesis', name: 'objenesis', version: '3.0.1'
-    testCompile 'org.springframework.boot:spring-boot:1.2.1.RELEASE' // For OutputCapture
+    testImplementation group: 'cglib', name: 'cglib-nodep', version: '2.2'
+    testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.0.1'
+    testImplementation 'org.springframework.boot:spring-boot:1.2.1.RELEASE' // For OutputCapture
 
     implementation 'info.picocli:picocli:4.6.1'
 
-    compile 'net.sf.opencsv:opencsv:2.3'
+    implementation 'net.sf.opencsv:opencsv:2.3'
 
-    compile 'commons-cli:commons-cli:1.3.1'
+    implementation 'commons-cli:commons-cli:1.3.1'
 
-    compile 'net.glxn.qrgen:javase:2.0'
-    compile 'org.apache.pdfbox:pdfbox:2.0.0-RC3'
+    implementation 'net.glxn.qrgen:javase:2.0'
+    implementation 'org.apache.pdfbox:pdfbox:2.0.0-RC3'
 
-    compile group: 'org.apache.xmlgraphics', name: 'batik-svggen', version: '1.10'
-    compile group: 'org.apache.xmlgraphics', name: 'batik-dom', version: '1.10'
+    implementation group: 'org.apache.xmlgraphics', name: 'batik-svggen', version: '1.10'
+    implementation group: 'org.apache.xmlgraphics', name: 'batik-dom', version: '1.10'
 
-    compile 'com.google.api-client:google-api-client:1.30.4'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.4'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
+    implementation 'com.google.api-client:google-api-client:1.30.4'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.30.4'
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
 
     clover 'org.openclover:clover:4.4.1'
 }


### PR DESCRIPTION
See https://docs.gradle.org/6.8.3/userguide/java_library_plugin.html#sec:java_library_configurations_graph

The error was:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings
```

Then when running with `--warning-mode all` the result was:

```
The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplement
ation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.8.3/userguide/upgrading_version_5.html#dep
endencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
```