### PR TITLE
Fix clover 'EmptyExpression.INSTANCE is immutable' errors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/CSVInput.groovy',
         '**/Feeders.groovy',
         '**/FeederTester.groovy',
         '**/BoardMirroring.groovy',

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/RowMatcher.groovy',
     ]
     testExcludes = [
             // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/DPVGenerator.groovy',
         '**/RowMatcher.groovy',
     ]
     testExcludes = [

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/DipTracePlacementsLineParser.groovy',
         '**/DPVFile.groovy',
         '**/DPVGenerator.groovy',
         '**/RowMatcher.groovy',

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/FeederTester.groovy',
         '**/BoardMirroring.groovy',
         '**/DiptraceComponentPlacementTransformer.groovy',
         '**/DipTracePlacementsLineParser.groovy',

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/DiptraceComponentPlacementTransformer.groovy',
         '**/DipTracePlacementsLineParser.groovy',
         '**/DPVFile.groovy',
         '**/DPVGenerator.groovy',

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/DPVFile.groovy',
         '**/DPVGenerator.groovy',
         '**/RowMatcher.groovy',
     ]

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,7 @@ clover {
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
     ]
     testExcludes = [
-            // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-            '**/DPVFileParserSpec.groovy',
+        // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
     ]
 
     report {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/BoardMirroring.groovy',
         '**/DiptraceComponentPlacementTransformer.groovy',
         '**/DipTracePlacementsLineParser.groovy',
         '**/DPVFile.groovy',

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ clover {
     testIncludes = ['**/*Spec.groovy']
     excludes = [
         // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
-        '**/Feeders.groovy',
         '**/FeederTester.groovy',
         '**/BoardMirroring.groovy',
         '**/DiptraceComponentPlacementTransformer.groovy',

--- a/src/main/groovy/com/seriouslypro/csv/CSVInput.groovy
+++ b/src/main/groovy/com/seriouslypro/csv/CSVInput.groovy
@@ -44,13 +44,13 @@ class CSVInput<TResult, TColumn extends Enum> {
     }
 
     void parseLines(Closure c, Closure exceptionHandler = this.&defaultExceptionHandler) {
-        String[] line
+        String[] line = [] // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
 
         while ((line = inputCSVReader.readNext()) != null) {
             context.lineIndex++
             context.columnName = null
 
-            TResult t
+            TResult t = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
             try {
                 t = lineParser.parse(context, line)
             } catch(Exception cause) {

--- a/src/main/groovy/com/seriouslypro/eda/diptrace/placement/DipTracePlacementsLineParser.groovy
+++ b/src/main/groovy/com/seriouslypro/eda/diptrace/placement/DipTracePlacementsLineParser.groovy
@@ -18,7 +18,7 @@ class DipTracePlacementsLineParser extends CSVLineParserBase<ComponentPlacement,
         BigDecimal y = rowValues[columnIndex(context, DipTracePlacementsCSVHeaders.Y)] as BigDecimal
         Coordinate coordinate = new Coordinate(x: x, y: y)
 
-        PCBSide side
+        PCBSide side = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
         String sideValue = rowValues[columnIndex(context, DipTracePlacementsCSVHeaders.SIDE)]
 
         try {

--- a/src/main/groovy/com/seriouslypro/pnpconvert/BoardMirroring.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/BoardMirroring.groovy
@@ -6,7 +6,7 @@ class BoardMirroring {
 
     Coordinate applyMirroring(Coordinate coordinate) {
 
-        Coordinate m
+        Coordinate m = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
 
         if (mode == Mirroring.Mode.HORIZONTAL) {
             m = new Coordinate(x: coordinate.x, y: origin.y - (coordinate.y - origin.y))

--- a/src/main/groovy/com/seriouslypro/pnpconvert/DPVGenerator.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/DPVGenerator.groovy
@@ -151,7 +151,7 @@ class DPVGenerator {
                 materialAssignments[placement] = existingMaterialAssignment
             } else {
 
-                Integer feederId
+                Integer feederId = null
 
                 try {
                     feederId = assignFeederID(trayIdSequence, machine.trayIds, usedIDs, feeder)

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Feeders.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Feeders.groovy
@@ -157,7 +157,7 @@ class Feeders {
                     note = rowValues[columnIndex(context, FeederCSVColumn.NOTE)].trim()
                 }
 
-                String trayName
+                String trayName = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
 
                 if (hasColumn(FeederCSVColumn.TRAY_NAME)) {
                     trayName = rowValues[headerMappings[FeederCSVColumn.TRAY_NAME].index].trim()

--- a/src/main/groovy/com/seriouslypro/pnpconvert/updater/DPVFile.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/updater/DPVFile.groovy
@@ -23,7 +23,7 @@ class DPVFileParser {
         DPVFile dpvFile = new DPVFile()
 
         Scanner scanner = new Scanner(inputStream)
-        String line
+        String line = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
         line = nextLine(scanner)
 
         if (line != "separated") {
@@ -32,7 +32,7 @@ class DPVFileParser {
 
         Task task = Task.PROPERTY
 
-        DPVTable activeTable
+        DPVTable activeTable = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
 
         while (scanner.hasNextLine()) {
             line = nextLine(scanner)
@@ -87,8 +87,8 @@ class DPVFileParser {
     }
 
     void parseProperty(Properties properties, String line) {
-        String key
-        String value
+        String key = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
+        String value = null // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
 
         try {
             (key, value) = line.split(",", 2)

--- a/src/main/groovy/com/seriouslypro/pnpconvert/updater/RowMatcher.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/updater/RowMatcher.groovy
@@ -71,7 +71,7 @@ class RowMatcher {
         if (matchOptions.contains(MatchOption.DESCRIPTION)) {
             int sheetComponentNameIndex = sheetToEntryHeaderMapping.sheetIndex(Feeders.FeederCSVColumn.DESCRIPTION)
 
-            int descriptionIndex
+            int descriptionIndex = 0 // CLOVER assignment needed to prevent 'EmptyExpression.INSTANCE is immutable' error
             switch (noteParts.size()) {
                 case 1:
                 case 2:

--- a/src/test/groovy/com/seriouslypro/pnpconvert/updater/DPVFileParserSpec.groovy
+++ b/src/test/groovy/com/seriouslypro/pnpconvert/updater/DPVFileParserSpec.groovy
@@ -12,7 +12,7 @@ class DPVFileParserSpec extends Specification {
             InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8.name()))
 
         when:
-            DPVFile file = new DPVFileParser().parse(inputStream)
+            new DPVFileParser().parse(inputStream)
 
         then:
             UnsupportedDPVContent caught = thrown()
@@ -36,7 +36,7 @@ class DPVFileParserSpec extends Specification {
             InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8.name()))
 
         when:
-            DPVFile file = new DPVFileParser().parse(inputStream)
+            new DPVFileParser().parse(inputStream)
 
         then:
             noExceptionThrown()


### PR DESCRIPTION
Errors seemed to be caused by a few types of code style.

1) unused assignment, see 7e51d31b630467eb5d81bae224b0b77bbb17f32b
2) empty declaration followed by conditional code which makes the assignment or exits the block where the empty declaration occurs. see b3300fa18dad2d6edbe902478681f820fb5efcd0
3) empty declaration followed by switch or if statements that conditionally make assignments, see b55ceb301523cd9379e06a522fadcd9525bec595

All resulted in the following error:

```
Unused assignments were causing 'java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable'
```

stack track of one occurence:
```
java.lang.RuntimeException: Clover-for-Groovy failed to instrument Groovy source: D:\Users\Hydra\Documents\dev\projects\spracing-manufacturing\pnpconvert\src\main\groovy\com\seriouslypro\pnpconvert\Converter.groovy
        at com.atlassian.clover.instr.groovy.Grover.visit(Grover.java:330)
        at com.atlassian.clover.instr.groovy.Grover.visit(Grover.java:291)
        at org.codehaus.groovy.transform.ASTTransformationVisitor.lambda$addPhaseOperationsForGlobalTransforms$4(ASTTransformationVisitor.java:337)
        at org.codehaus.groovy.control.CompilationUnit$ISourceUnitOperation.doPhaseOperation(CompilationUnit.java:901)
        at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:671)
        at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:635)
        at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:610)
        at org.codehaus.groovy.tools.FileSystemCompiler.compile(FileSystemCompiler.java:311)
        at org.codehaus.groovy.tools.FileSystemCompiler.doCompilation(FileSystemCompiler.java:240)
        at org.codehaus.groovy.ant.Groovyc.runCompiler(Groovyc.java:1312)
        at org.codehaus.groovy.ant.Groovyc.compile(Groovyc.java:1362)
        at org.codehaus.groovy.ant.Groovyc.execute(Groovyc.java:886)
        at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
        at groovy.util.AntBuilder.performTask(AntBuilder.java:333)
        at groovy.util.AntBuilder.nodeCompleted(AntBuilder.java:278)
        at org.gradle.api.internal.project.ant.BasicAntBuilder.nodeCompleted(BasicAntBuilder.java:80)
        at sun.reflect.GeneratedMethodAccessor20.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.gradle.internal.metaobject.BeanDynamicObject$MetaClassAdapter.invokeMethod(BeanDynamicObject.java:484)
        at org.gradle.internal.metaobject.BeanDynamicObject.tryInvokeMethod(BeanDynamicObject.java:196)
        at org.gradle.internal.metaobject.AbstractDynamicObject.invokeMethod(AbstractDynamicObject.java:163)
        at org.gradle.api.internal.project.antbuilder.AntBuilderDelegate.nodeCompleted(AntBuilderDelegate.java:124)
        at groovy.util.BuilderSupport.doInvokeMethod(BuilderSupport.java:151)
        at groovy.util.BuilderSupport.invokeMethod(BuilderSupport.java:64)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:43)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:135)
        at com.bmuschko.gradle.clover.InstrumentCodeAction.compileGroovyAndJava(InstrumentCodeAction.groovy:288)
        at com.bmuschko.gradle.clover.InstrumentCodeAction.compileSrcFiles(InstrumentCodeAction.groovy:232)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:190)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:58)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:156)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:168)
        at com.bmuschko.gradle.clover.InstrumentCodeAction.compileClasses(InstrumentCodeAction.groovy:191)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:351)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:64)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:156)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:168)
        at com.bmuschko.gradle.clover.InstrumentCodeAction$_instrumentCode_closure1.doCall(InstrumentCodeAction.groovy:147)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:101)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:263)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1041)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:71)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:52)
        at org.gradle.api.internal.project.antbuilder.DefaultIsolatedAntBuilder$2.execute(DefaultIsolatedAntBuilder.java:154)
        at org.gradle.api.internal.project.antbuilder.DefaultIsolatedAntBuilder$2.execute(DefaultIsolatedAntBuilder.java:136)
        at org.gradle.api.internal.project.antbuilder.ClassPathToClassLoaderCache.withCachedClassLoader(ClassPathToClassLoaderCache.java:135)
        at org.gradle.api.internal.project.antbuilder.DefaultIsolatedAntBuilder.execute(DefaultIsolatedAntBuilder.java:130)
        at org.gradle.api.internal.project.IsolatedAntBuilder$execute$0.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
        at com.bmuschko.gradle.clover.InstrumentCodeAction.instrumentCode(InstrumentCodeAction.groovy:92)
        at com.bmuschko.gradle.clover.InstrumentCodeAction$instrumentCode$0.callCurrent(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:156)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:168)
        at com.bmuschko.gradle.clover.InstrumentCodeAction.execute(InstrumentCodeAction.groovy:76)
        at com.bmuschko.gradle.clover.InstrumentCodeAction$execute.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127)
        at com.bmuschko.gradle.clover.CloverInstrumentationTask.instrumentCode(CloverInstrumentationTask.groovy:72)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:104)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
        at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$2.run(ExecuteActionsTaskExecuter.java:494)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:75)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:153)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:56)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.lambda$run$1(DefaultBuildOperationExecutor.java:71)
        at org.gradle.internal.operations.UnmanagedBuildOperationWrapper.runWithUnmanagedSupport(UnmanagedBuildOperationWrapper.java:45)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:71)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:479)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:462)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.access$400(ExecuteActionsTaskExecuter.java:105)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$TaskExecution.executeWithPreviousOutputFiles(ExecuteActionsTaskExecuter.java:273)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$TaskExecution.execute(ExecuteActionsTaskExecuter.java:251)
        at org.gradle.internal.execution.steps.ExecuteStep.lambda$executeOperation$1(ExecuteStep.java:66)
        at java.util.Optional.orElseGet(Optional.java:267)
        at org.gradle.internal.execution.steps.ExecuteStep.executeOperation(ExecuteStep.java:66)
        at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:34)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:47)
        at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:44)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:200)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:195)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:75)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:153)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:62)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.lambda$call$2(DefaultBuildOperationExecutor.java:76)
        at org.gradle.internal.operations.UnmanagedBuildOperationWrapper.callWithUnmanagedSupport(UnmanagedBuildOperationWrapper.java:54)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:76)
        at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:44)
        at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:34)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:72)
        at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:42)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:53)
        at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:39)
        at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:44)
        at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:77)
        at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:58)
        at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:54)
        at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:32)
        at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:57)
        at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:38)
        at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:63)
        at org.gradle.internal.execution.steps.BroadcastChangingOutputsStep.execute(BroadcastChangingOutputsStep.java:30)
        at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:176)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:76)
        at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:47)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:43)
        at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:32)
        at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:39)
        at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:25)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:102)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$0(SkipUpToDateStep.java:95)
        at java.util.Optional.map(Optional.java:215)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:55)
        at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:39)
        at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:83)
        at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:44)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
        at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:96)
        at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:52)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:83)
        at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:54)
        at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:74)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.lambda$execute$2(SkipEmptyWorkStep.java:88)
        at java.util.Optional.orElseGet(Optional.java:267)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:88)
        at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:34)
        at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
        at org.gradle.internal.execution.steps.LoadExecutionStateStep.execute(LoadExecutionStateStep.java:46)
        at org.gradle.internal.execution.steps.LoadExecutionStateStep.execute(LoadExecutionStateStep.java:34)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:43)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter$TaskExecution$3.withWorkspace(ExecuteActionsTaskExecuter.java:286)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:43)
        at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:33)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:40)
        at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:30)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:54)
        at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:40)
        at org.gradle.internal.execution.impl.DefaultExecutionEngine.execute(DefaultExecutionEngine.java:41)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:183)
        at java.util.Optional.orElseGet(Optional.java:267)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:183)
        at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:173)
        at org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:109)
        at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:62)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:56)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:200)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:195)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:75)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:153)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:68)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:62)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.lambda$call$2(DefaultBuildOperationExecutor.java:76)
        at org.gradle.internal.operations.UnmanagedBuildOperationWrapper.callWithUnmanagedSupport(UnmanagedBuildOperationWrapper.java:54)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:76)
        at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
        at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:41)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:411)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:398)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:391)
        at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:377)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.lambda$run$0(DefaultPlanExecutor.java:127)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:191)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.executeNextNode(DefaultPlanExecutor.java:182)
        at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:124)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable
        at org.codehaus.groovy.ast.expr.EmptyExpression$1.throwUnsupportedOperationException(EmptyExpression.java:63)
        at org.codehaus.groovy.ast.expr.EmptyExpression$1.setSourcePosition(EmptyExpression.java:95)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.transform(InstrumentingCodeVisitor.java:358)
        at org.codehaus.groovy.ast.expr.DeclarationExpression.transformExpression(DeclarationExpression.java:183)
        at org.codehaus.groovy.ast.ClassCodeExpressionTransformer.transform(ClassCodeExpressionTransformer.java:48)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.transform(InstrumentingCodeVisitor.java:309)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.visitExpressionStatement(InstrumentingCodeVisitor.java:633)
        at org.codehaus.groovy.ast.stmt.ExpressionStatement.visit(ExpressionStatement.java:40)
        at org.codehaus.groovy.ast.CodeVisitorSupport.visitBlockStatement(CodeVisitorSupport.java:86)
        at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitBlockStatement(ClassCodeVisitorSupport.java:164)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.visitBlockStatement(InstrumentingCodeVisitor.java:675)
        at org.codehaus.groovy.ast.stmt.BlockStatement.visit(BlockStatement.java:69)
        at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClassCodeContainer(ClassCodeVisitorSupport.java:138)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.visitConstructorOrMethod(InstrumentingCodeVisitor.java:250)
        at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitMethod(ClassCodeVisitorSupport.java:106)
        at org.codehaus.groovy.ast.ClassNode.visitMethods(ClassNode.java:1099)
        at org.codehaus.groovy.ast.ClassNode.visitContents(ClassNode.java:1092)
        at org.codehaus.groovy.ast.ClassCodeVisitorSupport.visitClass(ClassCodeVisitorSupport.java:52)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.visitClass(InstrumentingCodeVisitor.java:210)
        at com.atlassian.clover.instr.groovy.InstrumentingCodeVisitor.instrument(InstrumentingCodeVisitor.java:194)
        at com.atlassian.clover.instr.groovy.Grover.addRecorderIncCalls(Grover.java:362)
        at com.atlassian.clover.instr.groovy.Grover.visit(Grover.java:317)
        ... 222 more
```

The workaround prior to this was to use clover's grade build configuration settings 'excludes' and 'testExcludes', as follows:

```
clover {
    testIncludes = ['**/*Spec.groovy']
    excludes = [
        // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
        '**/SomeFile.groovy'
    ]
    testExcludes = [
        // All the following cause: java.lang.UnsupportedOperationException: EmptyExpression.INSTANCE is immutable"
        '**/SomeFileSpec.groovy'
    ]
}
```