### PR TITLE
Improved part mapping

### DIFF
--- a/examples/example1-270-with-rails-log.txt
+++ b/examples/example1-270-with-rails-log.txt
@@ -41,30 +41,39 @@ placement substitutions:
 [refdes:D3, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 [refdes:D4, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 
-placement component mappings:
-[refdes:D1, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:R3, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R4, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R5, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:D2, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D3, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D4, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:U1, name:STM32F030C8T, value:] -> [part code:STM32F030C8T6, manufacturer:ST] <- [name pattern:/STM32F030C8T(6)?/, value pattern:/.*/]'
-[refdes:R1, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+mappedPlacements:
+ ??placement [refdes:D1, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D2, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D3, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D4, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:U1, name:STM32F030C8T, value:]
+    ??component [partCode:STM32F030C8T6, manufacturer:ST, description:STM32F030C8T6]
 
 
 *** ISSUES ***
 
 
 unmappedPlacements:
-[refdes:R3, name:RES_2512, value:]
-[refdes:R4, name:RES_2512, value:]
-[refdes:R5, name:RES_2512, value:]
-[refdes:R1, name:RES_2512, value:]
+ ??placement [refdes:R3, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R4, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R5, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R1, name:RES_2512, value:]
+    ??criteria [part code:null, manufacturer:null]
+       ??errors
+          ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 
 *** MATERIAL ASSIGNMENTS *** - Components from the design that matched the components and feeders/trays
 

--- a/examples/example1-270-with-rails.dpv
+++ b/examples/example1-270-with-rails.dpv
@@ -1,8 +1,8 @@
 separated
 FILE,examples/example1-270-with-rails.dpv
 PCBFILE,examples/example1.csv
-DATE,2024/03/29
-TIME,11:33:25
+DATE,2024/03/30
+TIME,00:31:25
 PANELYPE,0
 
 Table,No.,ID,DeltX,DeltY,FeedRates,Note,Height,Speed,Status,SizeX,SizeY,HeightTake,DelayTake,nPullStripSpeed

--- a/examples/example1-2x1-panel-with-rails-TOP.dpv
+++ b/examples/example1-2x1-panel-with-rails-TOP.dpv
@@ -1,8 +1,8 @@
 separated
 FILE,examples/example1-2x1-panel-with-rails-TOP.dpv
 PCBFILE,examples/example1.csv
-DATE,2024/03/29
-TIME,11:33:30
+DATE,2024/03/30
+TIME,00:31:30
 PANELYPE,1
 
 Table,No.,ID,DeltX,DeltY,FeedRates,Note,Height,Speed,Status,SizeX,SizeY,HeightTake,DelayTake,nPullStripSpeed

--- a/examples/example1-90-with-rails-log.txt
+++ b/examples/example1-90-with-rails-log.txt
@@ -41,30 +41,39 @@ placement substitutions:
 [refdes:D3, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 [refdes:D4, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 
-placement component mappings:
-[refdes:D1, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:R3, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R4, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R5, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:D2, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D3, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D4, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:U1, name:STM32F030C8T, value:] -> [part code:STM32F030C8T6, manufacturer:ST] <- [name pattern:/STM32F030C8T(6)?/, value pattern:/.*/]'
-[refdes:R1, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+mappedPlacements:
+ ??placement [refdes:D1, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D2, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D3, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D4, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:U1, name:STM32F030C8T, value:]
+    ??component [partCode:STM32F030C8T6, manufacturer:ST, description:STM32F030C8T6]
 
 
 *** ISSUES ***
 
 
 unmappedPlacements:
-[refdes:R3, name:RES_2512, value:]
-[refdes:R4, name:RES_2512, value:]
-[refdes:R5, name:RES_2512, value:]
-[refdes:R1, name:RES_2512, value:]
+ ??placement [refdes:R3, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R4, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R5, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R1, name:RES_2512, value:]
+    ??criteria [part code:null, manufacturer:null]
+       ??errors
+          ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 
 *** MATERIAL ASSIGNMENTS *** - Components from the design that matched the components and feeders/trays
 

--- a/examples/example1-90-with-rails.dpv
+++ b/examples/example1-90-with-rails.dpv
@@ -1,8 +1,8 @@
 separated
 FILE,examples/example1-90-with-rails.dpv
 PCBFILE,examples/example1.csv
-DATE,2024/03/29
-TIME,11:33:17
+DATE,2024/03/30
+TIME,00:31:18
 PANELYPE,0
 
 Table,No.,ID,DeltX,DeltY,FeedRates,Note,Height,Speed,Status,SizeX,SizeY,HeightTake,DelayTake,nPullStripSpeed

--- a/examples/example1-job1-log.txt
+++ b/examples/example1-job1-log.txt
@@ -42,30 +42,39 @@ placement substitutions:
 [refdes:D3, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 [refdes:D4, name:DIODE_0805, value:] -> [name:DIODE_0805, value:40V 0.5A 0805] <- [name pattern:DIODE_0805, value pattern:]
 
-placement component mappings:
-[refdes:D1, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:R3, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R4, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:R5, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
-[refdes:D2, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D3, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:D4, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
-[refdes:U1, name:STM32F030C8T, value:] -> [part code:STM32F030C8T6, manufacturer:ST] <- [name pattern:/STM32F030C8T(6)?/, value pattern:/.*/]'
-[refdes:R1, name:RES_2512, value:] -> [part code:null, manufacturer:null]
-??? error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+mappedPlacements:
+ ??placement [refdes:D1, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D2, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D3, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:D4, name:DIODE_0805, value:40V 0.5A 0805]
+ ?  ??component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
+ ??placement [refdes:U1, name:STM32F030C8T, value:]
+    ??component [partCode:STM32F030C8T6, manufacturer:ST, description:STM32F030C8T]
 
 
 *** ISSUES ***
 
 
 unmappedPlacements:
-[refdes:R3, name:RES_2512, value:]
-[refdes:R4, name:RES_2512, value:]
-[refdes:R5, name:RES_2512, value:]
-[refdes:R1, name:RES_2512, value:]
+ ??placement [refdes:R3, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R4, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R5, name:RES_2512, value:]
+ ?  ??criteria [part code:null, manufacturer:null]
+ ?     ??errors
+ ?        ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
+ ??placement [refdes:R1, name:RES_2512, value:]
+    ??criteria [part code:null, manufacturer:null]
+       ??errors
+          ??no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 
 *** MATERIAL ASSIGNMENTS *** - Components from the design that matched the components and feeders/trays
 

--- a/examples/feeders.dpv
+++ b/examples/feeders.dpv
@@ -1,8 +1,8 @@
 separated
 FILE,examples/feeders.dpv
 PCBFILE,NONE
-DATE,2024/03/29
-TIME,11:33:32
+DATE,2024/03/30
+TIME,00:31:33
 PANELYPE,0
 
 Table,No.,ID,DeltX,DeltY,FeedRates,Note,Height,Speed,Status,SizeX,SizeY,HeightTake,DelayTake,nPullStripSpeed

--- a/src/main/groovy/com/seriouslypro/pnpconvert/Feeder.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/Feeder.groovy
@@ -3,7 +3,7 @@ package com.seriouslypro.pnpconvert
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
-@ToString
+@ToString(includeNames = true, includePackage = false)
 @EqualsAndHashCode
 class Feeder {
     Optional<Integer> fixedId = Optional.empty()

--- a/src/main/groovy/com/seriouslypro/pnpconvert/MaterialSelectionEntry.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/MaterialSelectionEntry.groovy
@@ -1,8 +1,10 @@
 package com.seriouslypro.pnpconvert
 
+import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
 @ToString(includeNames = true, includePackage = false)
+@EqualsAndHashCode
 class MaterialSelectionEntry {
     Component component
     Feeder feeder

--- a/src/main/groovy/com/seriouslypro/pnpconvert/MaterialSelector.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/MaterialSelector.groovy
@@ -1,76 +1,77 @@
 package com.seriouslypro.pnpconvert
 
 import com.seriouslypro.eda.part.PartMapping
+import com.seriouslypro.util.ascii.TreeNode
+import com.seriouslypro.util.ascii.TreePrinter
 
 class MaterialSelector {
-    Set<Component> unloadedComponents = []
+    Set<PlacementMapping> unloadedPlacements = []
     Set<PlacementMapping> unmappedPlacements = []
+    TreeNode<String> mappedPlacementsRoot = new TreeNode("mappedPlacements:")
 
     Map<ComponentPlacement, MaterialSelectionEntry> selectMaterials(List<ComponentPlacement> placements, List<Component> components, List<PartMapping> partMappings, List<Feeder> feeders) {
 
         Map<ComponentPlacement, MaterialSelectionEntry> materialSelections = [:]
 
         List<PlacementMapping> placementMappings = new PlacementMapper().map(placements, components, partMappings)
-        System.out.println()
-        System.out.println("placement component mappings:")
         placementMappings.each { PlacementMapping mappedPlacement ->
-            def placementSummary = [
-                refdes: mappedPlacement.placement.refdes,
-                name: mappedPlacement.placement.name,
-                value: mappedPlacement.placement.value,
-            ]
-            System.out.print("${placementSummary} -> ")
+            TreeNode<String> placementMappingNode = new TreeNode(buildPlacementSummary(mappedPlacement))
 
-            ComponentCriteria componentCriteria = new ComponentCriteria(
-                partCode: mappedPlacement.componentCriteria.partCode,
-                manufacturer: mappedPlacement.componentCriteria.manufacturer,
-            )
+            int unmappedCount = 0
+            Optional<Feeder> selectedFeeder = Optional.empty()
+            Optional<MappingResult> selectedResult = Optional.ofNullable(mappedPlacement.mappingResults.findResult { mr ->
 
-            System.out.print("${componentCriteria.toSummary()}")
+                MappingResult selectedResult = null
+                if (mr.component.isPresent()) {
+                    Component c = mr.component.get()
 
-            mappedPlacement.partMapping.ifPresent { partMapping ->
-                def partMappingSummary = [
-                    'name pattern': partMapping.namePattern,
-                    'value pattern': partMapping.valuePattern,
-                ]
-                System.out.print(" <- ${partMappingSummary}'")
-            }
+                    Optional<Feeder> of = findFeederByComponent(feeders, mr.criteria)
 
-            System.out.println()
-            if (mappedPlacement.errors) {
-                mappedPlacement.errors.eachWithIndex { error, i ->
-                    String indentation = '' // add unused assignment to prevent 'EmptyExpression.INSTANCE is immutable' error with clover
-                    if (i == mappedPlacement.errors.size() - 1) {
-                        indentation = '└── '
-                    } else {
-                        indentation = '├── '
+                    of.ifPresent {f ->
+                        MaterialSelectionEntry materialSelection = new MaterialSelectionEntry(
+                            component: c,
+                            feeder: f,
+                        )
+                        materialSelections[mappedPlacement.placement] = materialSelection
+                        selectedFeeder = Optional.of(f)
+
+                        TreeNode<String> componentNode = new TreeNode(buildComponentSummary(c))
+                        placementMappingNode.addChild(componentNode)
+
+                        selectedResult = mr
                     }
-                    System.out.println(indentation + "error: ${error}")
-                }
-            }
+                } else {
+                    if (!mr.partMapping.isPresent()) {
+                        unmappedCount += 1
+                    }
 
-            if (!mappedPlacement.component.isPresent()) {
+                }
+
+                selectedResult
+            })
+
+            if (unmappedCount > 0 && !selectedResult.isPresent()) {
                 unmappedPlacements << mappedPlacement
                 return
             }
 
-            Component component = mappedPlacement.component.get()
-            Feeder feeder = findFeederByComponent(feeders, componentCriteria)
-            if (!feeder) {
-                unloadedComponents << component
+            if (!selectedFeeder.isPresent()) {
+                unloadedPlacements << mappedPlacement
                 return
             }
 
-            MaterialSelectionEntry materialSelection = new MaterialSelectionEntry(
-                component: component,
-                feeder: feeder,
-            )
+            if (selectedResult.isPresent()) {
+                mappedPlacementsRoot.addChild(placementMappingNode)
+            }
 
-            materialSelections[mappedPlacement.placement] = materialSelection
         }
 
         System.out.println()
-        boolean showIssues = !unmappedPlacements.empty || !unloadedComponents.empty
+        List<String> lines = new TreePrinter().print(mappedPlacementsRoot)
+        lines.each { line -> System.out.println(line) }
+
+        System.out.println()
+        boolean showIssues = !unmappedPlacements.empty || !unloadedPlacements.empty
         if (showIssues) {
             System.out.println()
             System.out.println('*** ISSUES ***')
@@ -79,28 +80,82 @@ class MaterialSelector {
 
         if (!unmappedPlacements.empty) {
             System.out.println()
-            System.out.println("unmappedPlacements:\n" + unmappedPlacements.collect { PlacementMapping p -> [
-                refdes: p.placement.refdes,
-                name: p.placement.name,
-                value: p.placement.value,
-            ]}.join('\n'))
+            dumpPlacementMappings("unmappedPlacements:", unmappedPlacements)
         }
 
-        if (!unloadedComponents.empty) {
+        if (!unloadedPlacements.empty) {
             System.out.println()
-            System.out.println("unloadedComponents:\n" + unloadedComponents.collect {Component c -> [
-                partCode: c.partCode,
-                manufacturer: c.manufacturer,
-                description: c.description,
-            ]}.join('\n'))
+            dumpPlacementMappings("unloadedComponents:", unloadedPlacements)
         }
 
         return materialSelections
     }
 
-    Feeder findFeederByComponent(List<Feeder> feeders, ComponentCriteria criteria) {
-        return feeders.findResult { Feeder feeder ->
+    private dumpPlacementMappings(String title, Set<PlacementMapping> mappings) {
+
+        TreeNode<String> root = new TreeNode(title)
+
+        mappings.each { pm ->
+            TreeNode<String> pmNode = new TreeNode(buildPlacementSummary(pm))
+            root.addChild(pmNode)
+
+            pm.mappingResults.each { mr ->
+                TreeNode<String> criteriaNode = new TreeNode("criteria " + mr.criteria.toSummary())
+                pmNode.addChild(criteriaNode)
+
+                mr.component.ifPresent { c ->
+                    TreeNode<String> componentNode = new TreeNode(buildComponentSummary(c))
+                    criteriaNode.addChild(componentNode)
+                }
+                int totalErrors = pm.errors.size()
+                if (totalErrors > 0) {
+                    TreeNode<String> errorTitleNode = new TreeNode("errors")
+                    criteriaNode.addChild(errorTitleNode)
+                    pm.errors.each { error ->
+                        TreeNode<String> errorNode = new TreeNode(error)
+                        errorTitleNode.addChild(errorNode)
+                    }
+                }
+            }
+        }
+
+        List<String> lines = new TreePrinter().print(root)
+        lines.each { line -> System.out.println(line) }
+    }
+
+    private String buildComponentSummary(Component c) {
+        def componentSummary = [
+            partCode    : c.partCode,
+            manufacturer: c.manufacturer,
+            description : c.description,
+        ]
+        "component ${componentSummary}"
+    }
+
+    private String buildPlacementSummary(PlacementMapping pm) {
+        def placementSummary = [
+            refdes: pm.placement.refdes,
+            name  : pm.placement.name,
+            value : pm.placement.value,
+        ]
+        "placement ${placementSummary}"
+    }
+
+    private String buildTree(int i, int total) {
+        String indentation = ''
+        // add unused assignment to prevent 'EmptyExpression.INSTANCE is immutable' error with clover
+        if (i == total - 1) {
+            indentation = '└── '
+        } else {
+            indentation = '├── '
+        }
+        indentation
+    }
+
+    Optional<Feeder> findFeederByComponent(List<Feeder> feeders, ComponentCriteria criteria) {
+        Feeder feeder = feeders.findResult { Feeder feeder ->
             criteria.matches(feeder.partCode, feeder.manufacturer) ? feeder : null
         }
+        Optional.ofNullable(feeder)
     }
 }

--- a/src/main/groovy/com/seriouslypro/pnpconvert/PlacementMapping.groovy
+++ b/src/main/groovy/com/seriouslypro/pnpconvert/PlacementMapping.groovy
@@ -6,12 +6,16 @@ import groovy.transform.ToString
 
 @ToString(includeNames = true, includePackage = false)
 @EqualsAndHashCode
+class MappingResult {
+    ComponentCriteria criteria
+    Optional<PartMapping> partMapping
+    Optional<Component> component
+}
+
+@ToString(includeNames = true, includePackage = false)
+@EqualsAndHashCode
 class PlacementMapping {
     ComponentPlacement placement
-
-    Optional<Component> component = Optional.empty()
-    Optional<PartMapping> partMapping = Optional.empty()
-
-    ComponentCriteria componentCriteria
+    List<MappingResult> mappingResults = []
     List<String> errors = []
 }

--- a/src/main/groovy/com/seriouslypro/util/ascii/TreeNode.groovy
+++ b/src/main/groovy/com/seriouslypro/util/ascii/TreeNode.groovy
@@ -1,0 +1,14 @@
+package com.seriouslypro.util.ascii
+
+class TreeNode<T> {
+    T value
+    List<TreeNode<T>> children = []
+
+    TreeNode(T value) {
+        this.value = value
+    }
+
+    void addChild(TreeNode child) {
+        this.children << child
+    }
+}

--- a/src/main/groovy/com/seriouslypro/util/ascii/TreePrinter.groovy
+++ b/src/main/groovy/com/seriouslypro/util/ascii/TreePrinter.groovy
@@ -1,0 +1,43 @@
+package com.seriouslypro.util.ascii
+
+class TreePrinter<T> {
+    private final String CROSS = " ├─";
+    private final String CORNER = " └─";
+    private final String VERTICAL = " │ ";
+    private final String SPACE = "   ";
+
+    List<String> lines
+    String line
+
+    List<String> print(TreeNode<T> node) {
+        lines = []
+        line = ""
+        printNode(node, "")
+
+        lines
+    }
+
+    void printNode(TreeNode<T> node, String indent) {
+        line += node.value.toString()
+        lines << line
+        line = ""
+
+        var childrenCount = node.children.size()
+        node.children.eachWithIndex { TreeNode<T> child, int i ->
+            boolean isLast = i == (childrenCount - 1)
+            printChild(child, indent, isLast)
+        }
+    }
+
+    void printChild(TreeNode<T> node, String indent, boolean isLast) {
+        line += indent
+        if (isLast) {
+            line += CORNER
+            indent += SPACE
+        } else {
+            line += CROSS
+            indent += VERTICAL
+        }
+        printNode(node, indent)
+    }
+}

--- a/src/test/groovy/com/seriouslypro/pnpconvert/ConverterSpec.groovy
+++ b/src/test/groovy/com/seriouslypro/pnpconvert/ConverterSpec.groovy
@@ -97,6 +97,7 @@ class ConverterSpec extends Specification implements TestResources {
             String capturedOutput = capture.toString()
 
             !capturedOutput.contains("*** ISSUES ***")
+            capturedOutput ==~ /(?s)(.*)mappedPlacements:(.*)placement(.*)refdes:R1(.*)component(.*)CRG0402F10K(.*)placement(.*)refdes:C1(.*)component(.*)0402B104K500CT(.*)/
     }
 
     /**
@@ -134,6 +135,11 @@ class ConverterSpec extends Specification implements TestResources {
         and:
             String svgContent = new File(expectedSVGFileName).text
             !svgContent.empty
+
+        and:
+            String capturedOutput = capture.toString()
+            !capturedOutput.contains("*** ISSUES ***")
+            capturedOutput ==~ /(?s)(.*)mappedPlacements:(.*)placement(.*)refdes:R1(.*)component(.*)CRG0402F10K(.*)/
     }
 
     /**
@@ -174,8 +180,8 @@ class ConverterSpec extends Specification implements TestResources {
         and:
             String capturedOutput = capture.toString()
 
-            capturedOutput ==~ /(?s)(.*)placement component mappings(.*)refdes:C1(.*)no matching components(.*)/
-            capturedOutput ==~ /(?s)(.*)ISSUES(.*)unmappedPlacements(.*)refdes:C1(.*)/
+            capturedOutput ==~ /(?s)(.*)mappedPlacements:(.*)refdes:C1(.*)/
+            capturedOutput ==~ /(?s)(.*)ISSUES(.*)unmappedPlacements:(.*)refdes:C1(.*)no matching components(.*)/
     }
 
     /**
@@ -210,6 +216,10 @@ class ConverterSpec extends Specification implements TestResources {
         and:
             String svgContent = new File(expectedSVGFileName).text
             !svgContent.empty
+
+        and:
+            String capturedOutput = capture.toString()
+            capturedOutput ==~ /(?s)(.*)ISSUES(.*)unmappedPlacements:(.*)refdes:R1(.*)no matching components(.*)refdes:C1(.*)no matching components(.*)/
     }
 
     @Ignore


### PR DESCRIPTION
Allow part mapper to map to more than one component and allow components to be selected for any feeder which has any of the components.  Greatly improve readability of the results by using an ascii tree.

* First feeder matching the first part mapping wins.

After:
```
mappedPlacements:
 ├─placement [refdes:D1, name:DIODE_0805, value:40V 0.5A 0805]
 │  └─component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
 ├─placement [refdes:D2, name:DIODE_0805, value:40V 0.5A 0805]
 │  └─component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
 ├─placement [refdes:D3, name:DIODE_0805, value:40V 0.5A 0805]
 │  └─component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
 ├─placement [refdes:D4, name:DIODE_0805, value:40V 0.5A 0805]
 │  └─component [partCode:SD0805S040S0R5, manufacturer:KYOCERA, description:DIODE 40V 0.5A 0805]
 └─placement [refdes:U1, name:STM32F030C8T, value:]
    └─component [partCode:STM32F030C8T6, manufacturer:ST, description:STM32F030C8T6]


*** ISSUES ***


unmappedPlacements:
 ├─placement [refdes:R3, name:RES_2512, value:]
 │  └─criteria [part code:null, manufacturer:null]
 │     └─errors
 │        └─no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 ├─placement [refdes:R4, name:RES_2512, value:]
 │  └─criteria [part code:null, manufacturer:null]
 │     └─errors
 │        └─no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 ├─placement [refdes:R5, name:RES_2512, value:]
 │  └─criteria [part code:null, manufacturer:null]
 │     └─errors
 │        └─no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
 └─placement [refdes:R1, name:RES_2512, value:]
    └─criteria [part code:null, manufacturer:null]
       └─errors
          └─no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
```

Before:
```
placement component mappings:
[refdes:D1, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
[refdes:R3, name:RES_2512, value:] -> [part code:null, manufacturer:null]
└── error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
[refdes:R4, name:RES_2512, value:] -> [part code:null, manufacturer:null]
└── error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
[refdes:R5, name:RES_2512, value:] -> [part code:null, manufacturer:null]
└── error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings
[refdes:D2, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
[refdes:D3, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
[refdes:D4, name:DIODE_0805, value:40V 0.5A 0805] -> [part code:SD0805S040S0R5, manufacturer:KYOCERA] <- [name pattern:DIODE_0805, value pattern:40V 0.5A 0805]'
[refdes:U1, name:STM32F030C8T, value:] -> [part code:STM32F030C8T6, manufacturer:ST] <- [name pattern:/STM32F030C8T(6)?/, value pattern:/.*/]'
[refdes:R1, name:RES_2512, value:] -> [part code:null, manufacturer:null]
└── error: no matching components, check part code and manufacturer is correct, check or add components, use refdes replacements or part mappings


*** ISSUES ***


unmappedPlacements:
[refdes:R3, name:RES_2512, value:]
[refdes:R4, name:RES_2512, value:]
[refdes:R5, name:RES_2512, value:]
[refdes:R1, name:RES_2512, value:]
```

Example showing a 10K resistor that can be fulfilled by two different components by two different part mappings:
```
unloadedComponents:
 ├─placement [refdes:R1, name:RES_0402, value:10K 0402 1% 50V]
 │  ├─criteria [part code:WR04X1002FTL, manufacturer:WALSIN]
 │  │  └─component [partCode:WR04X1002FTL, manufacturer:WALSIN, description:RES, 10K, 1%, 50V, 0402, THICK FILM; Resistor Case Style:0402 [1005 Metric]; Resistance:10kohm; Product Range:WR04 Series; Voltage Rating:50V; Resistor Element Material:Thick Film; Power Rating:62.5mW; Resistance Toleran]
 │  └─criteria [part code:RC0402FR-0710KL, manufacturer:YAGEO]
 │     └─component [partCode:RC0402FR-0710KL, manufacturer:YAGEO, description:10K 0402 1% 50V/RES_0402]
...
```